### PR TITLE
Add getGeneLocation webservice method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ Version 2.0.6
 
 Release date to be decided.
 
+- Added `getGeneLocation` webservice method. Given a gene symbol and optional
+  genome build, it returns the location of the gene.
+
 
 Version 2.0.5
 -------------

--- a/mutalyzer/models.py
+++ b/mutalyzer/models.py
@@ -41,6 +41,23 @@ class SoapMessage(ComplexModel):
 #SoapMessage
 
 
+class GeneLocation(ComplexModel):
+    """
+    Return type of SOAP method getGeneLocation.
+    """
+    __namespace__ = SOAP_NAMESPACE
+
+    gene = Mandatory.Unicode
+    start = Mandatory.Integer
+    stop = Mandatory.Integer
+    orientation = Mandatory.Unicode
+    chromosome_name = Mandatory.Unicode
+    chromosome_accession = Mandatory.Unicode
+    assembly_name = Mandatory.Unicode
+    assembly_alias = Mandatory.Unicode
+#GeneLocation
+
+
 class Mapping(ComplexModel):
     """
     Return type of SOAP method mappingInfo.


### PR DESCRIPTION
Given a gene symbol and optional genome build, this returns the location
of the gene.

Primary motivation for this is LOVD, where it will be used in combination
with sliceChromsome as an alternative for sliceChromosomeByGene which only
works on the fixed Ensembl genome build.